### PR TITLE
Update roam-depot-export-formatter.json

### DIFF
--- a/extensions/ryanguill/roam-depot-export-formatter.json
+++ b/extensions/ryanguill/roam-depot-export-formatter.json
@@ -5,6 +5,6 @@
 	"tags": ["export", "formatting"],
 	"source_url": "https://github.com/ryanguill/roam-depot-export-formatter",
 	"source_repo": "https://github.com/ryanguill/roam-depot-export-formatter.git",
-	"source_commit": "5e190c9a12964ca3b6106dd055ee80b3430c89b2",
+	"source_commit": "9bdb3e92a08f23c764058ea8681e9fbd42df24cd",
 	"stripe_account": "acct_1Le7xkQmgYSLp29w"
   }


### PR DESCRIPTION
add css to make sure things still work in dark themes add ability to remove blocks containing queries
add copy markdown button